### PR TITLE
feat(ggw): auto-split diffs into semantically separate commits

### DIFF
--- a/apps/ggw/main.ts
+++ b/apps/ggw/main.ts
@@ -6,6 +6,7 @@ import { callLLM } from "@ggw/core/llm";
 import { spinner } from "@ggw/core/cui/spinner";
 import { fmt_output, yes_no } from "@ggw/core/cui/prompt";
 import { model_name_resolver } from "@ggw/core/cli/parser";
+import { splitDiffIntoCommits } from "@ggw/core/split";
 
 type Options = {
   model: string;
@@ -14,6 +15,7 @@ type Options = {
   path?: string;
   stdin: boolean;
   diff?: string[];
+  split: boolean;
 };
 
 const program = new Command();
@@ -31,7 +33,11 @@ program
   .option("-l, --lang <Lang>", "select lang")
   .option("-p, --path <Path>", "work path. git project root path.")
   .option("-I, --stdin", "use stdin as diff content")
-  .option("-D, --diff <Commit or branch...>", "diff range");
+  .option("-D, --diff <Commit or branch...>", "diff range")
+  .option(
+    "-s, --split",
+    "split semantically different changes into separate commits",
+  );
 program.parse();
 
 const options = program.opts<Options>();
@@ -62,7 +68,47 @@ const diff = await (async (use_stdin: boolean) => {
   }
 })(options.stdin);
 
-const git_st = JSON.stringify(await git.status());
+const status = await git.status();
+const git_st = JSON.stringify(status);
+
+if (options.split) {
+  const changed_files = status.files.map((f) => f.path);
+  if (changed_files.length === 0) {
+    console.error("No changes to commit.");
+    process.exit(1);
+  }
+
+  const groups = await spinner(
+    splitDiffIntoCommits({
+      provider,
+      model,
+      status: git_st,
+      diff,
+      files: changed_files,
+      lang,
+    }),
+    `Calling ${model} ...`,
+  );
+
+  const plan = groups
+    .map(
+      (g, i) => `[${i + 1}] ${g.message}\n    ${g.files.join("\n    ")}`,
+    )
+    .join("\n");
+  console.log(fmt_output(plan));
+
+  if (!(await yes_no(`create ${groups.length} commit(s) as above?`))) {
+    console.error("cancelled.");
+    process.exit(1);
+  }
+
+  for (const g of groups) {
+    await git.add(g.files);
+    await git.commit(g.message);
+  }
+  console.log("ok.");
+  process.exit(0);
+}
 
 const prompt = `You are an assistant that writes Git commit messages.\
 When code changes include modifications to documentation files (e.g., README.md, docs/), ignore those changes and generate the commit message based solely on source code changes.\

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,10 @@
     "./cui/semver": {
       "types": "./src/cui/semver.ts",
       "default": "./src/cui/semver.ts"
+    },
+    "./split": {
+      "types": "./src/split/index.ts",
+      "default": "./src/split/index.ts"
     }
   }
 }

--- a/packages/core/src/split/index.test.ts
+++ b/packages/core/src/split/index.test.ts
@@ -1,0 +1,98 @@
+import { expect, test, describe } from "bun:test";
+import { buildSplitPrompt, parseSplitResponse } from "./index";
+
+describe("split", () => {
+  describe("buildSplitPrompt", () => {
+    test("includes the changed files, status, diff and language", () => {
+      const prompt = buildSplitPrompt(
+        '{"modified":["a.ts"]}',
+        "diff --git a/a.ts b/a.ts",
+        ["a.ts", "b.ts"],
+        "Japanese",
+      );
+      expect(prompt).toContain("- a.ts");
+      expect(prompt).toContain("- b.ts");
+      expect(prompt).toContain('{"modified":["a.ts"]}');
+      expect(prompt).toContain("diff --git a/a.ts b/a.ts");
+      expect(prompt).toContain("Japanese");
+    });
+  });
+
+  describe("parseSplitResponse", () => {
+    const known = ["src/a.ts", "src/b.ts", "README.md"];
+
+    test("parses plain JSON into groups", () => {
+      const raw = JSON.stringify({
+        groups: [
+          { message: "feat: add a", files: ["src/a.ts"] },
+          { message: "docs: update readme", files: ["README.md"] },
+        ],
+      });
+      const groups = parseSplitResponse(raw, known);
+      expect(groups).toEqual([
+        { message: "feat: add a", files: ["src/a.ts"] },
+        { message: "docs: update readme", files: ["README.md"] },
+        { message: "chore: apply remaining changes", files: ["src/b.ts"] },
+      ]);
+    });
+
+    test("tolerates markdown code fences and surrounding prose", () => {
+      const raw =
+        'Here is the split:\n```json\n{"groups":[{"message":"fix: b","files":["src/b.ts"]}]}\n```\nDone.';
+      const groups = parseSplitResponse(raw, ["src/b.ts"]);
+      expect(groups).toEqual([{ message: "fix: b", files: ["src/b.ts"] }]);
+    });
+
+    test("drops unknown paths", () => {
+      const raw = JSON.stringify({
+        groups: [
+          { message: "feat: a", files: ["src/a.ts", "does/not/exist.ts"] },
+        ],
+      });
+      const groups = parseSplitResponse(raw, ["src/a.ts"]);
+      expect(groups).toEqual([{ message: "feat: a", files: ["src/a.ts"] }]);
+    });
+
+    test("assigns each file to only the first group that claims it", () => {
+      const raw = JSON.stringify({
+        groups: [
+          { message: "feat: a", files: ["src/a.ts"] },
+          { message: "chore: a again", files: ["src/a.ts"] },
+        ],
+      });
+      const groups = parseSplitResponse(raw, ["src/a.ts"]);
+      expect(groups).toEqual([{ message: "feat: a", files: ["src/a.ts"] }]);
+    });
+
+    test("collects unassigned files into a fallback group", () => {
+      const raw = JSON.stringify({ groups: [] });
+      const groups = parseSplitResponse(raw, ["src/a.ts", "src/b.ts"]);
+      expect(groups).toEqual([
+        {
+          message: "chore: apply remaining changes",
+          files: ["src/a.ts", "src/b.ts"],
+        },
+      ]);
+    });
+
+    test("skips groups with empty message or no valid files", () => {
+      const raw = JSON.stringify({
+        groups: [
+          { message: "   ", files: ["src/a.ts"] },
+          { message: "feat: b", files: [] },
+        ],
+      });
+      const groups = parseSplitResponse(raw, ["src/a.ts", "src/b.ts"]);
+      expect(groups).toEqual([
+        {
+          message: "chore: apply remaining changes",
+          files: ["src/a.ts", "src/b.ts"],
+        },
+      ]);
+    });
+
+    test("throws when no JSON object is present", () => {
+      expect(() => parseSplitResponse("not json at all", known)).toThrow();
+    });
+  });
+});

--- a/packages/core/src/split/index.ts
+++ b/packages/core/src/split/index.ts
@@ -1,0 +1,131 @@
+import { callLLM } from "../llm";
+
+/**
+ * A single commit produced by splitting a diff into semantically
+ * independent changes. `files` are the paths that should be staged and
+ * committed together, `message` is a single-line Conventional Commits
+ * message describing them.
+ */
+export type CommitGroup = {
+  message: string;
+  files: string[];
+};
+
+export type SplitParams = {
+  provider: string;
+  model: string;
+  status: string;
+  diff: string;
+  files: string[];
+  lang: string;
+};
+
+/**
+ * Build the prompt asking the LLM to group changed files into semantically
+ * independent commits.
+ */
+export function buildSplitPrompt(
+  status: string,
+  diff: string,
+  files: string[],
+  lang: string,
+): string {
+  return `You are an assistant that splits a set of Git changes into multiple, semantically independent commits.
+Analyze the git status and diff below and group the changed files so that each group represents ONE logical change.
+For each group, write a single-line commit message in Conventional Commits format (e.g. "feat:", "fix:", "docs:", "refactor:", "chore:").
+When code changes include modifications to documentation files (e.g. README.md, docs/), base the message on the source code changes.
+
+Rules:
+- Assign every changed file to exactly one group. Do not omit any file and do not repeat a file across groups.
+- Only use file paths from the "changed files" list below. Do not invent paths.
+- Prefer fewer groups; only split when the changes are genuinely unrelated. If everything belongs together, return a single group.
+- Output ONLY valid JSON, with no markdown, no code fences and no extra text, matching exactly this schema:
+{"groups":[{"message":"<commit message>","files":["<path>"]}]}
+
+changed files:
+${files.map((f) => `- ${f}`).join("\n")}
+
+status:
+${status}
+
+diff:
+${diff}
+
+Write the commit messages in ${lang}.`;
+}
+
+/**
+ * Extract the outermost JSON object from a raw LLM response, tolerating
+ * markdown code fences or surrounding prose.
+ */
+function extractJson(raw: string): string {
+  const trimmed = raw.trim();
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const body = fenceMatch ? fenceMatch[1].trim() : trimmed;
+  const start = body.indexOf("{");
+  const end = body.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error("no JSON object found in LLM response");
+  }
+  return body.slice(start, end + 1);
+}
+
+/**
+ * Parse the LLM response into commit groups.
+ *
+ * The result is validated against `knownFiles`: unknown paths are dropped,
+ * each file is assigned to at most one group (first occurrence wins), and
+ * any changed file the model failed to assign is collected into a final
+ * fallback group so that no change is silently lost.
+ */
+export function parseSplitResponse(
+  raw: string,
+  knownFiles: string[],
+): CommitGroup[] {
+  const parsed = JSON.parse(extractJson(raw)) as unknown;
+  const rawGroups =
+    parsed && typeof parsed === "object" && Array.isArray((parsed as { groups?: unknown }).groups)
+      ? ((parsed as { groups: unknown[] }).groups)
+      : [];
+
+  const known = new Set(knownFiles);
+  const seen = new Set<string>();
+  const groups: CommitGroup[] = [];
+
+  for (const g of rawGroups) {
+    if (!g || typeof g !== "object") continue;
+    const message = (g as { message?: unknown }).message;
+    const rawFiles = (g as { files?: unknown }).files;
+    if (typeof message !== "string" || !message.trim()) continue;
+    if (!Array.isArray(rawFiles)) continue;
+
+    const files = rawFiles.filter(
+      (f): f is string =>
+        typeof f === "string" && known.has(f) && !seen.has(f),
+    );
+    if (files.length === 0) continue;
+
+    files.forEach((f) => seen.add(f));
+    groups.push({ message: message.trim(), files });
+  }
+
+  const leftover = knownFiles.filter((f) => !seen.has(f));
+  if (leftover.length > 0) {
+    groups.push({ message: "chore: apply remaining changes", files: leftover });
+  }
+
+  return groups;
+}
+
+/**
+ * Ask the configured LLM to split the given changes into semantically
+ * independent commit groups.
+ */
+export async function splitDiffIntoCommits(
+  params: SplitParams,
+): Promise<CommitGroup[]> {
+  const { provider, model, status, diff, files, lang } = params;
+  const prompt = buildSplitPrompt(status, diff, files, lang);
+  const raw = await callLLM(provider, model, prompt);
+  return parseSplitResponse(raw, files);
+}


### PR DESCRIPTION
Add a `-s, --split` flag to `ggw` that, when the working tree contains
semantically unrelated changes, groups the changed files and creates one
commit per logical change instead of a single combined commit.

- Add `@ggw/core/split` module: builds an LLM prompt asking it to group
  changed files into semantically independent commits with a Conventional
  Commits message each, and robustly parses the JSON response (tolerates
  code fences, drops unknown paths, dedupes files across groups, and
  sweeps any unassigned changed files into a fallback group so nothing is
  lost).
- Wire the flag into `ggw`: show the proposed commit plan, confirm, then
  stage and commit each group in turn.
- Add unit tests for prompt construction and response parsing.

Closes #79

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WkE2RjS9uzzcPVjNfHsjvS